### PR TITLE
Allow php version >=7.2.5 for php 8 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.1.3|^8.0",
         "symfony/orm-pack": "*",
         "doctrine/annotations": "^1.6.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3|^8.0",
+        "php": ">=7.2.5",
         "symfony/orm-pack": "*",
         "doctrine/annotations": "^1.6.0"
     },


### PR DESCRIPTION
This PR will allow PHP version >=7.2.5 as well as for php 8 support.