### PR TITLE
Replace symfony/orm-pack with doctrine/orm to work with DBAL 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "symfony/orm-pack": "*"
+        "doctrine/orm": "*"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^4.1"


### PR DESCRIPTION
This PR replaces **symfony/orm-pack** with **doctrine/orm** as replaced package doesn't allow to install and use DBAL 4. 

See https://github.com/symfony/orm-pack/pull/43
And https://github.com/symfony/symfony/pull/52035#issuecomment-1978253065

I think this package not used inside of messenger so we could replace packages