### PR TITLE
Add .gitattributes to not distribute tests, phpunit configs, etc

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+/.gitattributes export-ignore
+/.github export-ignore
+/.gitignore export-ignore
+/phpunit.xml.dist export-ignore
+/tests export-ignore


### PR DESCRIPTION
This PR adds  .gitattributes to not distribute tests, phpunit configs, etc.

![image](https://github.com/user-attachments/assets/216b416c-31ee-4eab-9ac9-1bc9a2f73b5e)

Crossed files won't be a part of vendor folder which save a bit of space on the hard drive.
