### PR TITLE
Replace tagged (deprecated since 7.2) type with tagged_iterator

### DIFF
--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -43,7 +43,7 @@
         <service id="MonterHealth\ApiFilterBundle\MonterHealthApiFilter" alias="monter_health_api_filter.monter_health_api_filter" />
 
         <service id="monter_health_api_filter.monter_health_api_filter" class="MonterHealth\ApiFilterBundle\MonterHealthApiFilter" public="true">
-            <argument key="$filters" type="tagged" tag="monter_health_api_filter" />
+            <argument key="$filters" type="tagged_iterator" tag="monter_health_api_filter" />
             <argument key="$parameterCollectionFactory" type="service" id="monter_health_api_filter.parameter_collection_factory" />
             <argument key="$apiFilterFactory" type="service" id="monter_health_api_filter.api_filter_factory" />
             <argument key="$queryNameGenerator" type="service" id="monter_health_api_filter.query_name_generator" />


### PR DESCRIPTION
This PR removes deprecation note. `tagged` removed in Symfony 8 https://github.com/symfony/symfony/blob/8.0/UPGRADE-8.0.md#dependencyinjection.