### PR TITLE
Fix PHP >=8.4 deprecation note

### DIFF
--- a/src/Attribute/ApiFilter.php
+++ b/src/Attribute/ApiFilter.php
@@ -30,7 +30,7 @@ final class ApiFilter
     public array $properties = [];
     public array $arguments = [];
 
-    public function __construct(string $filterClass, string $id = null, string $strategy = null, array $properties = [], array $arguments = [])
+    public function __construct(string $filterClass, ?string $id = null, ?string $strategy = null, array $properties = [], array $arguments = [])
     {
         if (!is_a($filterClass, Filter::class, true)) {
             throw new \InvalidArgumentException(sprintf('The filter class "%s" does not implement "%s".', $filterClass, Filter::class));


### PR DESCRIPTION
This PR fixes PHP >=8.4 compatibility and Implicitly marking parameter $id and $strategy as nullable